### PR TITLE
Estilizando página de Detalhes

### DIFF
--- a/pokedex9/src/components/CardDetalhesPokemon/CardDetalhesPokemon.js
+++ b/pokedex9/src/components/CardDetalhesPokemon/CardDetalhesPokemon.js
@@ -1,39 +1,15 @@
 import React from "react";
-import { DetalhesContainer, StyleTitlePage } from "./styled";
-
+import { StyleDiv, StyleTitlePage, StyleParagraph } from "./styled";
 
 const CardDetalhesPokemon = (props) => {
 
     return (
-        <div>
-
-            <StyleTitlePage>{props.titulo}</StyleTitlePage>
-
-            <DetalhesContainer>
-                <div> 
-                    <div>
-                        <img src={props.imagemFront} alt="pokemon imagem de frente"/>
-                    </div>
-                    <div>
-                        <img src={props.imagemBack} alt="pokemon imagem de costas"/>
-                    </div>
-                </div>
+        <StyleDiv>
                 <div>
-                    <h2>Poderes</h2>
-                    <p>{props.poderes}</p>
-                   
+                    <StyleTitlePage>Poderes</StyleTitlePage>
+                    <StyleParagraph>{props.poderes}</StyleParagraph>
                 </div>
-                <div>
-                    <h2>Tipos de Poder</h2>
-                    <p>{props.tiposPoderes}</p>
-
-                    <h2>Principais Ataques</h2>
-                    <p>{props.principaisAtaques}</p>
-
-
-                </div>
-            </DetalhesContainer>
-        </div>
+        </StyleDiv>
     )
 }
 

--- a/pokedex9/src/components/CardDetalhesPokemon/styled.js
+++ b/pokedex9/src/components/CardDetalhesPokemon/styled.js
@@ -13,6 +13,7 @@ export const StyleDiv = styled.div`
     flex-direction: column;
     padding-bottom: 20px;
     border: 1px solid #000;
+    margin-bottom: 30px;
 `
 export const StyleTitlePage = styled.h2`
     font-size: 28px;

--- a/pokedex9/src/components/CardImageBack/CardImageBack.js
+++ b/pokedex9/src/components/CardImageBack/CardImageBack.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { StyleDiv, StyleImg } from "./styled";
+
+const CardImageBack = (props) => {
+    return(
+        <StyleDiv>
+            <StyleImg src={props.imagemBack} alt="pokemon imagem de frente"/>
+        </StyleDiv>
+    )
+};
+
+export default CardImageBack;

--- a/pokedex9/src/components/CardImageBack/styled.js
+++ b/pokedex9/src/components/CardImageBack/styled.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+import { blueColor, yellowColor, whiteColor } from '../../constants/cores'
+
+export const StyleDiv = styled.div`
+    display: flex;
+    height: 160px;
+    width: 170px;
+    border-radius: 30px;
+    background-color: ${whiteColor};
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    padding-bottom: 20px;
+    border: 1px solid #000;
+`
+
+export const StyleImg = styled.img`
+    display: flex;
+    width: 160px;
+    height: 160px;
+    margin-top: 10px;
+`

--- a/pokedex9/src/components/CardImageFront/CardImageFront.js
+++ b/pokedex9/src/components/CardImageFront/CardImageFront.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { StyleDiv, StyleImg } from "./styled";
+
+const CardImageFront = (props) => {
+    return(
+        <StyleDiv>
+            <StyleImg src={props.imagemFront} alt="pokemon imagem de frente"/>
+        </StyleDiv>
+    )
+};
+
+export default CardImageFront;

--- a/pokedex9/src/components/CardImageFront/styled.js
+++ b/pokedex9/src/components/CardImageFront/styled.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+import { blueColor, yellowColor, whiteColor } from '../../constants/cores'
+
+export const StyleDiv = styled.div`
+    display: flex;
+    height: 160px;
+    width: 170px;
+    border-radius: 30px;
+    background-color: ${whiteColor};
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    padding-bottom: 20px;
+    border: 1px solid #000;
+`
+
+export const StyleImg = styled.img`
+    display: flex;
+    width: 160px;
+    height: 160px;
+    margin-top: 10px;
+`

--- a/pokedex9/src/components/CardPokemon/styled.js
+++ b/pokedex9/src/components/CardPokemon/styled.js
@@ -5,7 +5,7 @@ export const StyleDiv = styled.div`
     display: flex;
     height: auto;
     min-height: 350px;
-    width: 340px;
+    width: 300px;
     border-radius: 55px;
     background-color: ${whiteColor};
     align-items: center;

--- a/pokedex9/src/components/CardPowerAndAttack/CardPowerAndAttack.js
+++ b/pokedex9/src/components/CardPowerAndAttack/CardPowerAndAttack.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { StyleDiv, StyleDivAttack, StyleTitlePage, StyleParagraph } from "./styled";
+
+const CardPowerAndAttack = (props) => {
+    return(
+        <div>
+            <StyleDiv>
+                    <StyleTitlePage>Tipos de Poder</StyleTitlePage>
+                    <StyleParagraph>{props.tiposPoderes}</StyleParagraph>
+            </StyleDiv>
+            <StyleDivAttack>
+                <StyleTitlePage>Principais Ataques</StyleTitlePage>
+                <StyleParagraph>{props.principaisAtaques}</StyleParagraph>
+            </StyleDivAttack>
+        </div>
+    )
+};
+
+export default CardPowerAndAttack;

--- a/pokedex9/src/components/CardPowerAndAttack/styled.js
+++ b/pokedex9/src/components/CardPowerAndAttack/styled.js
@@ -1,10 +1,11 @@
-import styled from "styled-components";
-import { blueColor, whiteColor } from "../../constants/cores";
+import React from "react";
+import styled from 'styled-components';
+import { whiteColor, blueColor } from "../../constants/cores";
 
 export const StyleDiv = styled.div`
     display: flex;
     height: auto;
-    min-height: 400px;
+    min-height: 200px;
     width: 340px;
     border-radius: 55px;
     background-color: ${whiteColor};
@@ -13,6 +14,21 @@ export const StyleDiv = styled.div`
     flex-direction: column;
     padding-bottom: 20px;
     border: 1px solid #000;
+    margin-bottom: 10px;
+`
+export const StyleDivAttack = styled.div`
+    display: flex;
+    height: auto;
+    min-height: 250px;
+    width: 340px;
+    border-radius: 55px;
+    background-color: ${whiteColor};
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    padding-bottom: 20px;
+    border: 1px solid #000;
+    margin-top: 30px;
 `
 export const StyleTitlePage = styled.h2`
     font-size: 28px;
@@ -23,7 +39,7 @@ export const StyleTitlePage = styled.h2`
 `
 export const StyleParagraph = styled.p`
     font-size: 18px;
-    font-weight: 700;
+    font-weight: 600;
     text-align: center;
     color: #000;
     margin-top: 30px;

--- a/pokedex9/src/components/CardPowerAndAttack/styled.js
+++ b/pokedex9/src/components/CardPowerAndAttack/styled.js
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from 'styled-components';
 import { whiteColor, blueColor } from "../../constants/cores";
 
@@ -6,7 +5,7 @@ export const StyleDiv = styled.div`
     display: flex;
     height: auto;
     min-height: 200px;
-    width: 340px;
+    width: 320px;
     border-radius: 55px;
     background-color: ${whiteColor};
     align-items: center;
@@ -20,7 +19,7 @@ export const StyleDivAttack = styled.div`
     display: flex;
     height: auto;
     min-height: 250px;
-    width: 340px;
+    width: 320px;
     border-radius: 55px;
     background-color: ${whiteColor};
     align-items: center;

--- a/pokedex9/src/components/Header/styled.js
+++ b/pokedex9/src/components/Header/styled.js
@@ -8,7 +8,8 @@ export const StyleMenu = styled.div`
   background-color: ${blueColor};
   align-items: center;    
   display: flex;
-  justify-content: space-between; 
+  justify-content: space-between;
+  gap: 10px; 
 `
 
 export const StyleLogo = styled.h1`

--- a/pokedex9/src/components/Header/styled.js
+++ b/pokedex9/src/components/Header/styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { blueColor, redColor, whiteColor } from '../../constants/cores'
 
 export const StyleMenu = styled.div`
-  width: 100%
+  width: auto;
   height: 100px;
   padding: 25px;
   background-color: ${blueColor};

--- a/pokedex9/src/pages/PokedexDetails/PokedexDetails.js
+++ b/pokedex9/src/pages/PokedexDetails/PokedexDetails.js
@@ -3,6 +3,10 @@ import { Header } from '../../components/Header/Header';
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import { useEffect, useState } from "react"
+import CardImageFront from "../../components/CardImageFront/CardImageFront";
+import CardImageBack from "../../components/CardImageBack/CardImageBack";
+import CardPowerAndAttack from "../../components/CardPowerAndAttack/CardPowerAndAttack";
+import { StyleDivImages, StyleDivContainer, StyleTitlePage} from "./styled";
 
 export const PokeDexDetails = () => {
 
@@ -36,42 +40,48 @@ export const PokeDexDetails = () => {
         })
 
     }, [id])
-
     
     return (
-        <div>
+         <div>
             <Header
-             disableButtonBack={false}
+                disableButtonBack={false}
             />
-            
-            <CardDetalhesPokemon
-                titulo={pokemonName}
-                imagemFront={pokemonsImg.front_default}
-                imagemBack={pokemonsImg.back_default}
-                poderes={pokemons.map((pokemon) => { 
-                    return (
-                        <div key={pokemon.stat.id}> 
-                            <p><strong>{pokemon.stat.name}: </strong>{pokemon.base_stat}</p>
-                        </div>
+            <StyleTitlePage>{pokemonName}</StyleTitlePage>
+            <StyleDivContainer>
+                <StyleDivImages>
+                    <CardImageFront
+                    imagemFront={pokemonsImg.front_default}
+                    />
+                    <CardImageBack
+                    imagemBack={pokemonsImg.back_default}
+                    />
+                </StyleDivImages>
+                    <CardDetalhesPokemon                
+                    poderes={pokemons.map((pokemon) => { 
+                        return (
+                            <div key={pokemon.stat.id}> 
+                                <p><strong>{pokemon.stat.name}: </strong>{pokemon.base_stat}</p>
+                            </div>
                     )
-                })}
-                tiposPoderes={pokemonsAbilites.map((typos) => { 
-                    return (
-                        <div key={typos.slot}> 
-                            <p>{typos.type.name}</p>
-                        </div>
+                    })}
+                    />
+                    <CardPowerAndAttack
+                        tiposPoderes={pokemonsAbilites.map((typos) => { 
+                            return (
+                                <div key={typos.slot}> 
+                                    <p>{typos.type.name}</p>
+                                </div>
                     )
-                })}
-                principaisAtaques={pokemonMoves.map((move, index) => { 
-                    return (
+                    })}
+                        principaisAtaques={pokemonMoves.map((move, index) => { 
+                            return (
 
-                        index < 5 && <p key={move.move.name}>{move.move.name}</p>
+                            index < 5 && <p key={move.move.name}>{move.move.name}</p>
 
                     )
-                })}
-          
-
-            />
-        </div >
+                    })}
+            /> 
+                </StyleDivContainer>
+            </div>
     )
 } 

--- a/pokedex9/src/pages/PokedexDetails/styled.js
+++ b/pokedex9/src/pages/PokedexDetails/styled.js
@@ -1,0 +1,28 @@
+import React from "react";
+import styled from 'styled-components';
+import { blueColor } from "../../constants/cores";
+
+export const StyleDivImages = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+`
+
+export const StyleDivContainer = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
+    margin-left: 120px;
+    margin-right: 60px;
+`
+export const StyleTitlePage = styled.h2`
+    font-size: 38px;
+    font-weight: 700;
+    text-align: center;
+    color: ${blueColor};
+    margin-top: 30px;
+    margin-bottom: 30px;
+    margin-left: -60px;
+`

--- a/pokedex9/src/pages/PokedexDetails/styled.js
+++ b/pokedex9/src/pages/PokedexDetails/styled.js
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from 'styled-components';
 import { blueColor } from "../../constants/cores";
 
@@ -6,6 +5,7 @@ export const StyleDivImages = styled.div`
     display: flex;
     flex-direction: column;
     gap: 30px;
+    margin-bottom: 30px;
 `
 
 export const StyleDivContainer = styled.div`
@@ -14,11 +14,9 @@ export const StyleDivContainer = styled.div`
     flex-direction: row;
     justify-content: space-evenly;
     align-items: center;
-    margin-left: 120px;
-    margin-right: 60px;
 `
 export const StyleTitlePage = styled.h2`
-    font-size: 38px;
+    font-size: 36px;
     font-weight: 700;
     text-align: center;
     color: ${blueColor};


### PR DESCRIPTION
Estilização da página de Detalhes finalizada. Separei alguns componentes do card de detalhes em outros componentes, pensando na responsividade no mobile.

Além disso, também fiz um ajuste no Header por conta do ; que estava faltando.

Link do surge para ver o projeto como está: pokedex-detalhes-used-support.surge.sh